### PR TITLE
Harden CheckoutWebView with file-access lockdown and host allow-list (closes #6)

### DIFF
--- a/payrails-lib/src/main/java/com/mirzakhanidehkordi/payrails_lib/ui/CheckoutWebView.kt
+++ b/payrails-lib/src/main/java/com/mirzakhanidehkordi/payrails_lib/ui/CheckoutWebView.kt
@@ -1,7 +1,7 @@
 package com.mirzakhanidehkordi.payrails_lib.ui
 
-import android.graphics.Bitmap
 import android.net.Uri
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
@@ -9,73 +9,91 @@ import androidx.compose.ui.viewinterop.AndroidView
 
 /**
  * A Composable function that displays a WebView for handling checkout processes.
- * It's designed to load a given URL and trigger a callback when a specific
- * "success" pattern is detected in the page URL, indicating completion.
+ * It loads a given URL and triggers a callback when the page navigates to one of
+ * the configured success or failure redirect URLs.
+ *
+ * Hardening notes:
+ *  - File access from WebView is disabled. The checkout flow is fully remote so
+ *    there is no reason to expose local files to the page.
+ *  - Navigations are restricted to an allow-list. Anything not on the list is
+ *    routed back to the host app via [onExternalNavigation] so the host can
+ *    decide whether to open the URL with an external intent.
+ *  - The deprecated `shouldOverrideUrlLoading(view, url: String?)` overload is
+ *    not used. The WebResourceRequest variant is the modern API and exposes
+ *    main-frame information needed to make safe routing decisions.
  *
  * @param url The URL to load in the WebView.
- * @param successRedirectUrl The expected URL to redirect to on successful completion.
- * @param failureRedirectUrl The expected URL to redirect to on failure/cancellation.
- * @param onComplete A lambda function to be invoked when the checkout process is considered complete (success).
- * @param onError A lambda function to be invoked when the checkout process ends with an error or cancellation.
+ * @param successRedirectUrl Prefix that signals a successful checkout.
+ * @param failureRedirectUrl Prefix that signals a failed or cancelled checkout.
+ * @param allowedHosts Hosts that are allowed to render inside the WebView. The
+ *   host of [url] is always added implicitly.
+ * @param onComplete Invoked once when the success URL is reached.
+ * @param onError Invoked when the failure URL is reached or a load error fires.
+ * @param onExternalNavigation Invoked when a navigation targets a host that is
+ *   not on the allow-list. The host app should typically launch an intent.
  */
 @Composable
 fun CheckoutWebView(
     url: String,
-    successRedirectUrl: String, // e.g., "https://yourapp.com/payrails/success" or a custom scheme
-    failureRedirectUrl: String, // e.g., "https://yourapp.com/payrails/failure"
+    successRedirectUrl: String,
+    failureRedirectUrl: String,
+    allowedHosts: Set<String> = emptySet(),
     onComplete: () -> Unit,
-    onError: (String) -> Unit // Pass an error message
+    onError: (String) -> Unit,
+    onExternalNavigation: (String) -> Unit = {}
 ) {
+    val initialHost = Uri.parse(url).host.orEmpty()
+    val effectiveAllowed = (allowedHosts + initialHost).filter { it.isNotBlank() }.toSet()
+
     AndroidView(factory = { context ->
         WebView(context).apply {
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = true // Often needed for modern web apps
-            settings.setSupportMultipleWindows(true) // If redirects open new windows
-
-            // Optional: Enable debug for WebView (for testing only, remove in prod)
-            // WebView.setWebContentsDebuggingEnabled(true)
+            with(settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                setSupportMultipleWindows(false)
+                allowFileAccess = false
+                allowContentAccess = false
+                @Suppress("DEPRECATION")
+                allowFileAccessFromFileURLs = false
+                @Suppress("DEPRECATION")
+                allowUniversalAccessFromFileURLs = false
+                setGeolocationEnabled(false)
+                javaScriptCanOpenWindowsAutomatically = false
+            }
 
             webViewClient = object : WebViewClient() {
-                /**
-                 * Intercept URL loading. This is the primary way to handle redirects.
-                 */
-                override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
-                    url?.let {
-                        val uri = Uri.parse(it)
-                        // This is a more robust way to handle callbacks:
-                        // 1. Using specific redirect URLs provided by Payrails or your own backend.
-                        // 2. Potentially using deep links/custom schemes like "yourapp://payrails/success"
-                        if (it.startsWith(successRedirectUrl)) {
-                            onComplete()
-                            return true // Indicate that we handled the URL
-                        } else if (it.startsWith(failureRedirectUrl)) {
-                            onError("Payment failed or cancelled.")
-                            return true // Indicate that we handled the URL
-                        }
-                        // Add more specific handling if Payrails provides other redirect types
-                        // For example, if it's a 3DS redirect, you might want to let the WebView load it.
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    val target = request?.url?.toString() ?: return false
+                    if (target.startsWith(successRedirectUrl)) {
+                        onComplete()
+                        return true
                     }
-                    return super.shouldOverrideUrlLoading(view, url) // Let the WebView load the URL normally
+                    if (target.startsWith(failureRedirectUrl)) {
+                        onError("Payment failed or cancelled.")
+                        return true
+                    }
+                    val host = request.url.host.orEmpty()
+                    val scheme = request.url.scheme.orEmpty().lowercase()
+                    val isWebScheme = scheme == "https" || scheme == "http"
+                    if (!isWebScheme || (effectiveAllowed.isNotEmpty() && host !in effectiveAllowed)) {
+                        onExternalNavigation(target)
+                        return true
+                    }
+                    return false
                 }
 
-                /**
-                 * Called when a page finishes loading.
-                 * This can be used for initial loading or fallback checks, but should not be the primary
-                 * mechanism for success/failure callbacks from payment gateways due to redirects.
-                 */
-                override fun onPageFinished(view: WebView?, pageUrl: String?) {
-                    super.onPageFinished(view, pageUrl)
-                    // You can add additional checks here if the payment flow involves
-                    // JavaScript calls that set specific values that you can then read
-                    // using evaluateJavascript, but URL redirection is usually more reliable.
-                }
-
-                override fun onReceivedError(view: WebView?, errorCode: Int, description: String?, failingUrl: String?) {
+                override fun onReceivedError(
+                    view: WebView?,
+                    errorCode: Int,
+                    description: String?,
+                    failingUrl: String?
+                ) {
                     super.onReceivedError(view, errorCode, description, failingUrl)
-                    onError("WebView error: $description (Code: $errorCode)")
+                    onError("WebView error: $description (code $errorCode)")
                 }
-
-                // Add other overrides as needed, e.g., onReceivedSslError for SSL certificate issues.
             }
             loadUrl(url)
         }


### PR DESCRIPTION
## Harden `CheckoutWebView` against issue #6

Closes #6

### What changed

`payrails-lib/src/main/java/com/mirzakhanidehkordi/payrails_lib/ui/CheckoutWebView.kt`

The composable now configures the underlying `WebView` for a payment flow rather than for general browsing.

1. File and content access are turned off. The checkout pages are remote, so there is no reason for the WebView to read local files. This closes the most common WebView XSS path on Android.
2. Universal and file-origin access from `file://` URLs are explicitly disabled to defend against future code that might accidentally load a local document.
3. Navigations are restricted to an allow-list. The host of the initial URL is always allowed, and callers can pass extra hosts (for example a 3DS bank domain). Anything else is reported via a new `onExternalNavigation` callback so the host app can decide to open it with `Intent.ACTION_VIEW`.
4. `shouldOverrideUrlLoading` now uses the `WebResourceRequest` overload which is the supported API on every API level the library targets.
5. Multiple-window support and JS-driven popups are disabled. They are not needed by the redirect-based checkout flow and they make navigation routing ambiguous.

### Key snippet

```kotlin
with(settings) {
    javaScriptEnabled = true
    domStorageEnabled = true
    setSupportMultipleWindows(false)
    allowFileAccess = false
    allowContentAccess = false
    allowFileAccessFromFileURLs = false
    allowUniversalAccessFromFileURLs = false
    setGeolocationEnabled(false)
    javaScriptCanOpenWindowsAutomatically = false
}

override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
    val target = request?.url?.toString() ?: return false
    if (target.startsWith(successRedirectUrl)) { onComplete(); return true }
    if (target.startsWith(failureRedirectUrl)) { onError("Payment failed or cancelled."); return true }
    val host = request.url.host.orEmpty()
    val scheme = request.url.scheme.orEmpty().lowercase()
    val isWebScheme = scheme == "https" || scheme == "http"
    if (!isWebScheme || (effectiveAllowed.isNotEmpty() && host !in effectiveAllowed)) {
        onExternalNavigation(target)
        return true
    }
    return false
}
```

### Compatibility note

`CheckoutWebView` gains two optional parameters (`allowedHosts` and `onExternalNavigation`) with safe defaults. Existing callers compile unchanged.
